### PR TITLE
Update namespaces to use opf- prefix

### DIFF
--- a/kfdef/jupyterhub/kustomization.yaml
+++ b/kfdef/jupyterhub/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: odh-deployment-jupyterhub
+namespace: opf-jupyterhub
 resources:
   - kfdef.yaml

--- a/kfdef/superset/kustomization.yaml
+++ b/kfdef/superset/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: odh-deployment-superset
+namespace: opf-superset
 resources:
   - kfdef.yaml


### PR DESCRIPTION
The suggestion here is that the default namespaces for components  use the `opf-` prefix with the format opf-< component >