### PR TITLE
Make pre-commit happy

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,2 +1,3 @@
+---
 check:
   - thoth-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.1
+    rev: v1.1.9
     hooks:
       - id: remove-tabs
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v3.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -17,14 +17,8 @@ repos:
       - id: check-symlinks
       - id: detect-private-key
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.23.0
+    rev: v1.25.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/kfdef/jupyterhub/kfdef.yaml
+++ b/kfdef/jupyterhub/kfdef.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:

--- a/kfdef/jupyterhub/kustomization.yaml
+++ b/kfdef/jupyterhub/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-jupyterhub

--- a/kfdef/superset/kfdef.yaml
+++ b/kfdef/superset/kfdef.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:

--- a/kfdef/superset/kustomization.yaml
+++ b/kfdef/superset/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-superset

--- a/operator/base/kustomization.yaml
+++ b/operator/base/kustomization.yaml
@@ -1,6 +1,7 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: odh-operator
 resources:
-- operator_group.yaml
-- subscription.yaml
+  - operator_group.yaml
+  - subscription.yaml

--- a/operator/base/operator_group.yaml
+++ b/operator/base/operator_group.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/operator/base/subscription.yaml
+++ b/operator/base/subscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
Fixes #4 

- Consolidate `pre-commit-hooks` hooks into single version reference
- `pre-commit autoupdate` to newest versions
- Format YAMLs to make pre-commit happier