### PR TITLE
Add monitoring components for Jupyterhub deployment

### DIFF
--- a/kfdef/jupyterhub/kfdef.yaml
+++ b/kfdef/jupyterhub/kfdef.yaml
@@ -7,11 +7,24 @@ metadata:
   name: opendatahub
 spec:
   applications:
+    # ODH Common Components
     - kustomizeConfig:
         repoRef:
           name: manifests
           path: odh-common
       name: odh-common
+    # ODH Monitoring Components
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/cluster
+      name: prometheus-cluster
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/operator
+      name: prometheus-operator
+    # ODH Jupyterhub Components
     - kustomizeConfig:
         parameters:
           - name: s3_endpoint_url


### PR DESCRIPTION
This is a basic deployment of the Prometheus operator for the JH namespace.

We will still need to add a [servicemonitor](https://github.com/opendatahub-io/odh-manifests/blob/master/prometheus/operator/base/jupyterhub-servicemonitor.yaml) for the JH service to get scraped.