### PR TITLE
Add opf-monitoring namespace with Prometheus instance

### DIFF
--- a/kfdef/monitoring/kfdef.yaml
+++ b/kfdef/monitoring/kfdef.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    # ODH Common Components
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    # ODH Prometheus Operator Components
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/cluster
+      name: prometheus-cluster
+  repos:
+    - name: manifests
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.8.0"
+  version: v0.8.0

--- a/kfdef/monitoring/kustomization.yaml
+++ b/kfdef/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-monitoring
+resources:
+  - kfdef.yaml
+  - prometheus.yaml
+  - prometheus-route.yaml

--- a/kfdef/monitoring/prometheus-route.yaml
+++ b/kfdef/monitoring/prometheus-route.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: prometheus
+spec:
+  path: /
+  to:
+    kind: Service
+    name: prometheus-operated
+  port:
+    targetPort: web

--- a/kfdef/monitoring/prometheus.yaml
+++ b/kfdef/monitoring/prometheus.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: odh-monitoring
+  labels:
+    app: prometheus
+    prometheus: k8s
+spec:
+  serviceMonitorSelector: {}
+  securityContext: {}
+  ruleSelector: {}
+  replicas: 2
+  remoteRead:
+    - url: "http://prometheus-operated.opf-jupyterhub.svc.cluster.local:9090\
+            /api/v1/read"


### PR DESCRIPTION
Will need to add a route for public access
This will read metrics from opf-jupyterhub prometheus using remote read