### PR TITLE
Updated "notebook-images/" to include ocp-ci-analysis project

### DIFF
--- a/kfdef/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdef/jupyterhub/notebook-images/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: opf-jupyterhub
 resources:
   - categorical-encoding.yaml
+  - ocp-ci-analysis.yaml

--- a/kfdef/jupyterhub/notebook-images/ocp-ci-analysis.yaml
+++ b/kfdef/jupyterhub/notebook-images/ocp-ci-analysis.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/ocp-ci-analysis"
+    opendatahub.io/notebook-image-name:
+      "Openshift CI Analysis Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebook image for the OpenShift CI Analysis project"
+  name: ocp-ci-analysis
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/ocp-ci-analysis
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/ocp-ci-analysis:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"


### PR DESCRIPTION
This PR updates `kfdef/jupyterhub/notebook-images/kustomization.yaml` and added `kfdef/jupyterhub/notebook-images/ocp-ci-analysis.yaml` so that this [repo](https://github.com/aicoe-aiops/ocp-ci-analysis) would be included and available as a deployable image on MOC JH. 