### PR TITLE
Add hard drive failure prediction notebook img to notebook-images

### DIFF
--- a/kfdef/jupyterhub/notebook-images/ceph-drive-failure.yaml
+++ b/kfdef/jupyterhub/notebook-images/ceph-drive-failure.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/ceph_drive_failure"
+    opendatahub.io/notebook-image-name:
+      "Ceph Hard Drive Failure Prediction Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebook image for hard drive failure prediction models"
+  name: ceph-drive-failure
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/ceph-drive-failure
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/ceph-drive-failure:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"

--- a/kfdef/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdef/jupyterhub/notebook-images/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: opf-jupyterhub
 resources:
   - categorical-encoding.yaml
   - ocp-ci-analysis.yaml
+  - ceph-drive-failure.yaml


### PR DESCRIPTION
Since all the data, models, and notebooks are already open source for the hard drive failure prediction project, we could make the image available in public facing JH as well.