### PR TITLE
added notebook images for configuration file analysis project

### DIFF
--- a/kfdef/jupyterhub/notebook-images/configuration-files-analysis.yaml
+++ b/kfdef/jupyterhub/notebook-images/configuration-files-analysis.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/configuration-files-analysis"
+    opendatahub.io/notebook-image-name:
+      "Configuration File Analysis Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebook image for the Configuration File Analysis project"
+  name: configuration-files-analysis
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/configuration-files-analysis
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/configuration-files-analysis:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"

--- a/kfdef/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdef/jupyterhub/notebook-images/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - categorical-encoding.yaml
   - ocp-ci-analysis.yaml
   - ceph-drive-failure.yaml
+  - configuration-files-analysis.yaml


### PR DESCRIPTION
This is related to [issue](https://github.com/aicoe-aiops/configuration-files-analysis/issues/14)

This PR updates kfdef/jupyterhub/notebook-images/kustomization.yaml and added kfdef/jupyterhub/notebook-images/configuration-files-analysis.yaml so that config file analysis repo would be included and available as a deployable image on MOC JH. 