### PR TITLE
feat(datacatalog): Deploy Thrift Server, Hue, Ceph into a single namespace

### DIFF
--- a/kfdef/datacatalog/kfdef.yaml
+++ b/kfdef/datacatalog/kfdef.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: radanalyticsio/spark/cluster
+      name: radanalyticsio-spark-cluster
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: ceph
+          path: ceph/object-storage/scc
+      name: ceph-nano-scc
+    - kustomizeConfig:
+        repoRef:
+          name: ceph
+          path: ceph/object-storage/nano
+      name: ceph-nano
+    - kustomizeConfig:
+        parameters:
+          - name: s3_endpoint_url
+            value: ceph-nano-0
+          - name: s3_is_secure
+            value: "false"
+          - name: s3_credentials_secret
+            value: ceph-nano-credentials
+        repoRef:
+          name: hue
+          path: hue/hue
+      name: hue
+    - kustomizeConfig:
+        overlays:
+          - create-spark-cluster
+        parameters:
+          - name: s3_endpoint_url
+            value: ceph-nano-0
+          - name: s3_credentials_secret
+            value: ceph-nano-credentials
+        repoRef:
+          name: thrift
+          path: thriftserver/thriftserver
+      name: thriftserver
+  repos:
+    - name: manifests
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0"
+    - name: hue
+      uri: "https://github.com/tumido/odh-manifests/tarball/datacatalog-hue"
+    - name: thrift
+      uri: "https://github.com/tumido/odh-manifests/tarball/datacatalog-thriftserver"  # yamllint disable-line rule:line-length
+    - name: ceph
+      uri: "https://github.com/tumido/odh-manifests/tarball/ceph-credentials"
+  version: v0.9-branch-openshift

--- a/kfdef/datacatalog/kustomization.yaml
+++ b/kfdef/datacatalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-datacatalog
+resources:
+  - kfdef.yaml


### PR DESCRIPTION
Resolves: #15

Requires: https://github.com/opendatahub-io/odh-manifests/pull/227, https://github.com/opendatahub-io/odh-manifests/pull/228, https://github.com/opendatahub-io/odh-manifests/pull/250, https://gitlab.com/opendatahub/opendatahub-images/-/merge_requests/4, https://gitlab.com/opendatahub/opendatahub-images/-/merge_requests/5

Deploy full data catalog:
- Hue
- Thrift server
- Minimal spark cluster for Thrift server
- Ceph

It also interconnects:
- Hue -> Thrift Server
- Hue -> Ceph
- Thrift Server -> Spark
- Thrift Server -> Ceph