### PR TITLE
feat: Add dashboard

### DIFF
--- a/kfdef/dashboard/kfdef.yaml
+++ b/kfdef/dashboard/kfdef.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-dashboard
+      name: odh-dashboard
+    - kustomizeConfig:
+        overlays:
+          - custom-image
+          - cluster-role
+        repoRef:
+          name: opf
+          path: kfdef/dashboard/overrides
+      name: odh-dashboard
+  repos:
+    - name: manifests
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0"
+    - name: opf
+      uri: "https://github.com/operate-first/odh/tarball/master"
+  version: v0.9.0

--- a/kfdef/dashboard/kustomization.yaml
+++ b/kfdef/dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-dashboard
+resources:
+  - kfdef.yaml

--- a/kfdef/dashboard/overrides/overlays/cluster-role/kustomization.yaml
+++ b/kfdef/dashboard/overrides/overlays/cluster-role/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+resources:
+  - rbac.yaml

--- a/kfdef/dashboard/overrides/overlays/cluster-role/rbac.yaml
+++ b/kfdef/dashboard/overrides/overlays/cluster-role/rbac.yaml
@@ -1,0 +1,51 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+rules:
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kfdef.apps.kubeflow.org
+    resources:
+      - kfdefs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odh-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: odh-dashboard
+    namespace: opf-dashboard

--- a/kfdef/dashboard/overrides/overlays/custom-image/kustomization.yaml
+++ b/kfdef/dashboard/overrides/overlays/custom-image/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+images:
+  - name: quay.io/opendatahub/odh-dashboard:v0.9
+    newName: quay.io/operate-first/odh-dashboard
+    newTag: v0.9


### PR DESCRIPTION
Resolves: #12 

Deploys a **fork** of the ODH Dashboard with following patches applied:

- https://github.com/opendatahub-io/odh-dashboard/pull/32
- https://github.com/opendatahub-io/odh-dashboard/pull/31
- https://github.com/opendatahub-io/odh-dashboard/pull/27

This is baked into a custom image at https://quay.io/repository/tcoufal/odh-dashboard

Additionally to that it deploys a `ClusterRole` with a `ClusterRoleBinding`, allowing `odh-dashboard` service account to look up all the namespaces and consume `kfdef` resouces from them.

Example:
![image](https://user-images.githubusercontent.com/7453394/100898547-29d3a200-34c1-11eb-8690-8d000dc9bfdf.png)
Here you can see Argo running at `opf-argo` and Hue with Thrift server running at `opf-datacatalog`. All located successfully, with routes as well. 
 