### PR TITLE
[Monitoring] Add argocd wave annotations for monitoring resources

### DIFF
--- a/kfdef/monitoring/grafana.yaml
+++ b/kfdef/monitoring/grafana.yaml
@@ -1,6 +1,8 @@
 apiVersion: integreatly.org/v1alpha1
 kind: Grafana
 metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
     name: grafana
 spec:
     baseImage: quay.io/app-sre/grafana:7.1.1

--- a/kfdef/monitoring/kfdef.yaml
+++ b/kfdef/monitoring/kfdef.yaml
@@ -3,6 +3,7 @@ apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: "0"
     kfctl.kubeflow.io/force-delete: "false"
   name: opendatahub
 spec:

--- a/kfdef/monitoring/prometheus-route.yaml
+++ b/kfdef/monitoring/prometheus-route.yaml
@@ -2,6 +2,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   name: prometheus
 spec:
   path: /

--- a/kfdef/monitoring/prometheus.yaml
+++ b/kfdef/monitoring/prometheus.yaml
@@ -2,6 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   name: odh-monitoring
   labels:
     app: prometheus


### PR DESCRIPTION
Adding these annotations will make argocd deploy the kfdef first (wave 0)
and then rest of the resources will be created (wave 1)

Closes #44  