### PR TITLE
Add JH monitoring back in and fix kustomize build error for jh

### DIFF
--- a/base/jupyterhub/kfdef.yaml
+++ b/base/jupyterhub/kfdef.yaml
@@ -13,6 +13,16 @@ spec:
           path: odh-common
       name: odh-common
     - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/cluster
+      name: prometheus-cluster
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/operator
+      name: prometheus-operator
+    - kustomizeConfig:
         overlays: []
         parameters:
           - name: s3_endpoint_url


### PR DESCRIPTION
Was accidentally removed in #46 
This also happened to break the `kustomize build` for JH because the overlays index had changed. 