### PR TITLE
correct the example name referenced

### DIFF
--- a/docs/add_kafka_topics.md
+++ b/docs/add_kafka_topics.md
@@ -10,7 +10,7 @@ Replace `my-topic` with a preferred name.
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaTopic
 metadata:
-  name: orders
+  name: my-topic
   labels:
     strimzi.io/cluster: odh-message-bus
 spec:


### PR DESCRIPTION
Based on the following statement: `Replace my-topic with a preferred name.`
the example component name should be `my-topic`.

correct the example name referenced
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>